### PR TITLE
fix: replace node-fetch with native fetch in Netlify functions

### DIFF
--- a/src/functions/contact.ts
+++ b/src/functions/contact.ts
@@ -1,6 +1,5 @@
 import type { Handler } from '@netlify/functions';
 
-import fetch from 'node-fetch';
 import type { Contact } from '~/types';
 import sanitize from '~/utils/sanitize';
 import validations from '~/utils/validations';

--- a/src/functions/reviews.ts
+++ b/src/functions/reviews.ts
@@ -1,5 +1,4 @@
 import type { Handler } from '@netlify/functions';
-import fetch from 'node-fetch';
 import type { Review } from '~/types';
 
 const { GOOGLE_MAPS_API_KEY, GOOGLE_MAPS_PLACE_ID } = process.env;
@@ -35,7 +34,7 @@ const handler: Handler = async ({ httpMethod }) => {
     };
   }
   return await fetch(placesQuery)
-    .then((res: { json: () => Promise<GooglePlacesResponse> }) => res.json())
+    .then((res) => res.json() as Promise<GooglePlacesResponse>)
     .then((data: GooglePlacesResponse) => ({
       headers,
       statusCode: 200,


### PR DESCRIPTION
Node.js v18+ includes a native fetch API, so the node-fetch package
is unnecessary and was causing build failures when bundling functions.

https://claude.ai/code/session_01LxcKAfn45bWZea8Ju8LGf4