### PR TITLE
Afficher toutes les réalisations triées par date décroissante

### DIFF
--- a/src/components/realisations/LatestRealisations.astro
+++ b/src/components/realisations/LatestRealisations.astro
@@ -1,6 +1,6 @@
 ---
 import { getRealisationsPermalink } from '~/utils/permalinks';
-import { findLatestRealisations } from '~/utils/realisations';
+import { fetchRealisations } from '~/utils/realisations';
 import SwiperRealisations from '../widgets/SwiperRealisations.astro';
 
 export interface Props {
@@ -8,7 +8,6 @@ export interface Props {
   allRealisationsText?: string;
   allRealisationsLink?: string | URL;
   information?: string;
-  count?: number;
 }
 
 const {
@@ -16,10 +15,9 @@ const {
   allRealisationsText = 'Voir mes autres réalisations',
   allRealisationsLink = getRealisationsPermalink(),
   information = await Astro.slots.render('information'),
-  count = 6,
 } = Astro.props;
 
-const posts = await findLatestRealisations({ count });
+const posts = await fetchRealisations();
 ---
 
 <section class="mx-auto max-w-6xl py-12 lg:py-18">

--- a/src/components/realisations/ListItem.astro
+++ b/src/components/realisations/ListItem.astro
@@ -25,7 +25,7 @@ const link = !REALISATIONS?.post?.disabled ? getPermalink(post.permalink, 'reali
   {
     image && (
       <a class="group relative block" href={link} title="Voir les photos">
-        <div class="relative h-0 overflow-hidden rounded bg-gray-400 pb-[56.25%] shadow-lg md:h-72  md:pb-[75%] lg:pb-[56.25%]">
+        <div class="relative h-0 overflow-hidden rounded bg-gray-400 pb-[75%] shadow-lg">
           {image && (
             <Image
               src={image}
@@ -34,7 +34,7 @@ const link = !REALISATIONS?.post?.disabled ? getPermalink(post.permalink, 'reali
               sizes="(max-width: 900px) 400px, 900px"
               alt={post.title || post.accroche || ''}
               width={900}
-              height={506}
+              height={675}
               loading="lazy"
               decoding="async"
             />


### PR DESCRIPTION
Remplace findLatestRealisations (limitée à 6) par fetchRealisations
pour afficher l'intégralité des réalisations dans la section
"Mes dernières réalisations", triées de la plus récente à la plus ancienne.

https://claude.ai/code/session_01XTzREd3L6PEzsssXBB3p7b