### PR TITLE
Slightly widen review comment cards on mobile

### DIFF
--- a/src/components/review/Review.tsx
+++ b/src/components/review/Review.tsx
@@ -6,7 +6,7 @@ type ReviewProps = {
 
 export default function Reviews({ review }: ReviewProps) {
   return (<div
-    className="review flex flex-col gap-2 px-8 py-6 bg-gray-100 rounded-sm mb-6 review-header"
+    className="review flex flex-col gap-2 px-5 py-6 bg-gray-100 rounded-sm mb-6 review-header"
     key={`${review.text}${review.author_name}`}
   >
     <div className="flex gap-4 items-center review-header ">

--- a/src/components/review/Reviews.astro
+++ b/src/components/review/Reviews.astro
@@ -25,7 +25,7 @@ import ReviewsComponent from './Reviews';
         />
       </div>
 
-      <div class="w-full shrink-0 grow-0 basis-auto p-4 lg:w-2/3">
+      <div class="w-full shrink-0 grow-0 basis-auto p-2 lg:p-4 lg:w-2/3">
         <ReviewsComponent initialReviews={initialReviews} client:load />
       </div>
     </div>


### PR DESCRIPTION
Reduce card horizontal padding from px-8 to px-5 and container
padding from p-4 to p-2 on mobile to give comments more width.

https://claude.ai/code/session_01DS27BNF3PQpJKGYASUwQ8P