### PR TITLE
Ajoute une galerie PhotoSwipe avec 5 photos avant la section réalisations

### DIFF
--- a/src/components/photoswipe/HomeGallery.astro
+++ b/src/components/photoswipe/HomeGallery.astro
@@ -1,0 +1,122 @@
+---
+import 'photoswipe/style.css';
+import { findImage } from '~/utils/images';
+
+const GALLERY_ID = 'home-gallery';
+
+const imagePaths = [
+  '/images/realisations/Macherie/93-min.webp',
+  '/images/realisations/Escalier1/1.webp',
+  '/images/realisations/Kiosque/1.webp',
+  '/images/realisations/Debord-de-toit-ferme-apparat/1.webp',
+  '/images/realisations/Charpente-Manoir-Bel-Noe/1.webp',
+];
+
+const resolvedImages = (
+  await Promise.all(
+    imagePaths.map(async (imgPath) => {
+      const src = await findImage(imgPath);
+      if (!src || typeof src === 'string') return null;
+      return { src };
+    })
+  )
+).filter(Boolean);
+---
+
+<style>
+  .home-gallery-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+    gap: 6px;
+  }
+
+  .home-gallery-grid .gallery-item-featured {
+    grid-column: 1;
+    grid-row: 1 / 3;
+  }
+
+  .home-gallery-grid .gallery-item {
+    grid-column: 2;
+  }
+
+  @media (min-width: 768px) {
+    .home-gallery-grid {
+      grid-template-columns: 2fr 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
+      gap: 8px;
+    }
+
+    .home-gallery-grid .gallery-item-featured {
+      grid-column: 1;
+      grid-row: 1 / 3;
+    }
+
+    .home-gallery-grid .gallery-item:nth-child(2) { grid-column: 2; grid-row: 1; }
+    .home-gallery-grid .gallery-item:nth-child(3) { grid-column: 3; grid-row: 1; }
+    .home-gallery-grid .gallery-item:nth-child(4) { grid-column: 2; grid-row: 2; }
+    .home-gallery-grid .gallery-item:nth-child(5) { grid-column: 3; grid-row: 2; }
+  }
+
+  .gallery-link {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    border-radius: 4px;
+  }
+
+  .gallery-link img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s ease;
+  }
+
+  .gallery-link:hover img {
+    transform: scale(1.04);
+  }
+
+  .home-gallery-grid {
+    height: 420px;
+  }
+
+  @media (min-width: 768px) {
+    .home-gallery-grid {
+      height: 520px;
+    }
+  }
+</style>
+
+<div id={GALLERY_ID} class="home-gallery-grid">
+  {
+    resolvedImages.map(({ src }, index) => (
+      <a
+        href={src.src}
+        class:list={['gallery-link', index === 0 ? 'gallery-item-featured' : 'gallery-item']}
+        data-pswp-width={src.width}
+        data-pswp-height={src.height}
+      >
+        <img
+          src={src.src}
+          alt={`Réalisation ${index + 1}`}
+          loading={index === 0 ? 'eager' : 'lazy'}
+          decoding="async"
+        />
+      </a>
+    ))
+  }
+</div>
+
+<script>
+  import PhotoSwipeLightbox from 'photoswipe/lightbox';
+
+  const lightbox = new PhotoSwipeLightbox({
+    gallerySelector: '#home-gallery',
+    childSelector: 'a',
+    pswpModule: () => import('photoswipe'),
+    paddingFn: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  });
+
+  lightbox.init();
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import Reviews from '~/components/review/Reviews.astro';
 import Contact from '~/components/contact/Contact.astro';
 import Presentation from '~/components/widgets/Presentation.astro';
 import AnimatedSection from '~/components/common/AnimatedSection.astro';
+import HomeGallery from '~/components/photoswipe/HomeGallery.astro';
 
 import { getCollection } from 'astro:content';
 import CategoriesGrid from '~/components/widgets/CategoriesGrid.astro';
@@ -64,6 +65,13 @@ const meta = {
         alt: 'Baptiste Clisson - Charpentier Traditionnel',
       }}
     />
+  </div>
+
+  <!-- Home Gallery PhotoSwipe ******* -->
+  <div class="container mx-auto px-4 py-8 sm:px-6">
+    <AnimatedSection reveal="fade-up">
+      <HomeGallery />
+    </AnimatedSection>
   </div>
 
   <!-- HighlightedRealisations Widget ******* -->


### PR DESCRIPTION
Crée HomeGallery.astro avec une grille CSS personnalisée (1 grande image +
4 vignettes) qui ouvre PhotoSwipe en plein écran au clic avec navigation
entre les photos.

https://claude.ai/code/session_012L7qB1Yt9UhzbKeyUMYyFL