### PR TITLE
Ajoute une galerie PhotoSwipe sur la page d'accueil

### DIFF
--- a/src/components/photoswipe/HomeGallery.astro
+++ b/src/components/photoswipe/HomeGallery.astro
@@ -5,7 +5,7 @@ import { findImage } from '~/utils/images';
 const GALLERY_ID = 'home-gallery';
 
 const imagePaths = [
-  '/images/realisations/Macherie/93-min.webp',
+  '/images/realisations/Escalier-exterieur-comtois/7.webp',
   '/images/realisations/Escalier1/1.webp',
   '/images/realisations/Kiosque/1.webp',
   '/images/realisations/Debord-de-toit-ferme-apparat/1.webp',

--- a/src/components/photoswipe/HomeGallery.astro
+++ b/src/components/photoswipe/HomeGallery.astro
@@ -24,38 +24,40 @@ const resolvedImages = (
 ---
 
 <style>
+  /* ── Mobile : portrait + horizontal à gauche / 3 empilées à droite ── */
   .home-gallery-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto auto;
+    grid-template-rows: 1fr 1fr 1fr;
     gap: 6px;
+    height: 500px;
   }
 
-  .home-gallery-grid .gallery-item-featured {
-    grid-column: 1;
-    grid-row: 1 / 3;
-  }
+  /* img1 — grand portrait, col gauche, rows 1-2 */
+  .home-gallery-grid .gallery-link:nth-child(1) { grid-column: 1; grid-row: 1 / 3; }
 
-  .home-gallery-grid .gallery-item {
-    grid-column: 2;
-  }
+  /* img2, img3, img4 — empilées col droite */
+  .home-gallery-grid .gallery-link:nth-child(2) { grid-column: 2; grid-row: 1; }
+  .home-gallery-grid .gallery-link:nth-child(3) { grid-column: 2; grid-row: 2; }
+  .home-gallery-grid .gallery-link:nth-child(4) { grid-column: 2; grid-row: 3; }
 
+  /* img5 — horizontale, col gauche, row 3 */
+  .home-gallery-grid .gallery-link:nth-child(5) { grid-column: 1; grid-row: 3; }
+
+  /* ── Desktop : grande image gauche + 2×2 à droite ── */
   @media (min-width: 768px) {
     .home-gallery-grid {
       grid-template-columns: 2fr 1fr 1fr;
       grid-template-rows: 1fr 1fr;
       gap: 8px;
+      height: 520px;
     }
 
-    .home-gallery-grid .gallery-item-featured {
-      grid-column: 1;
-      grid-row: 1 / 3;
-    }
-
-    .home-gallery-grid .gallery-item:nth-child(2) { grid-column: 2; grid-row: 1; }
-    .home-gallery-grid .gallery-item:nth-child(3) { grid-column: 3; grid-row: 1; }
-    .home-gallery-grid .gallery-item:nth-child(4) { grid-column: 2; grid-row: 2; }
-    .home-gallery-grid .gallery-item:nth-child(5) { grid-column: 3; grid-row: 2; }
+    .home-gallery-grid .gallery-link:nth-child(1) { grid-column: 1; grid-row: 1 / 3; }
+    .home-gallery-grid .gallery-link:nth-child(2) { grid-column: 2; grid-row: 1; }
+    .home-gallery-grid .gallery-link:nth-child(3) { grid-column: 3; grid-row: 1; }
+    .home-gallery-grid .gallery-link:nth-child(4) { grid-column: 2; grid-row: 2; }
+    .home-gallery-grid .gallery-link:nth-child(5) { grid-column: 3; grid-row: 2; }
   }
 
   .gallery-link {
@@ -76,16 +78,6 @@ const resolvedImages = (
   .gallery-link:hover img {
     transform: scale(1.04);
   }
-
-  .home-gallery-grid {
-    height: 420px;
-  }
-
-  @media (min-width: 768px) {
-    .home-gallery-grid {
-      height: 520px;
-    }
-  }
 </style>
 
 <div id={GALLERY_ID} class="home-gallery-grid">
@@ -93,7 +85,7 @@ const resolvedImages = (
     resolvedImages.map(({ src }, index) => (
       <a
         href={src.src}
-        class:list={['gallery-link', index === 0 ? 'gallery-item-featured' : 'gallery-item']}
+        class="gallery-link"
         data-pswp-width={src.width}
         data-pswp-height={src.height}
       >


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Crée le composant `HomeGallery.astro` avec 5 photos issues des réalisations
- Grille CSS responsive : layout différent mobile et desktop
- Clic sur une photo → PhotoSwipe plein écran avec navigation par swipe

## Layout

**Mobile** : portrait (col gauche, rows 1-2) + horizontal (col gauche, row 3) + 3 images empilées (col droite)

**Desktop** : grande image à gauche sur toute la hauteur + 2×2 à droite

## Plan de test

- [ ] Vérifier l'affichage de la grille sur mobile
- [ ] Vérifier l'affichage de la grille sur desktop
- [ ] Cliquer sur une photo → PhotoSwipe s'ouvre en plein écran
- [ ] Navigation swipe/flèches entre les 5 photos
- [ ] La galerie apparaît bien avant la section "Mes dernières réalisations"

https://claude.ai/code/session_012L7qB1Yt9UhzbKeyUMYyFL
EOF
)