### PR TITLE
fix: add overflow-x hidden on both html and body to prevent lateral s…

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -5,6 +5,11 @@
 @import "tailwindcss/preflight.css" layer(base);
 @import "tailwindcss/utilities.css" layer(utilities);
 
+html,
+body {
+  overflow-x: hidden;
+}
+
 :root {
   --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);


### PR DESCRIPTION
…croll

Single overflow-x:hidden on body is insufficient; browsers can still scroll the html element. Fixes horizontal scroll caused by reveal translateX animations and swiper overflow on mobile.

https://claude.ai/code/session_01Xg6rj7mzWAgHz2iQDebbuh